### PR TITLE
删除不必要的annotation

### DIFF
--- a/src/main/java/cn/org/hentai/dns/app/DNSCheaterApp.java
+++ b/src/main/java/cn/org/hentai/dns/app/DNSCheaterApp.java
@@ -10,21 +10,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
-import org.sqlite.SQLiteDataSource;
-
-import javax.sql.DataSource;
 
 /**
  * Created by matrixy on 2019/4/19.
  */
 @ComponentScan(value = {"cn.org.hentai"})
-@EnableAutoConfiguration
 @SpringBootApplication
 @MapperScan("cn.org.hentai.dns")
 public class DNSCheaterApp


### PR DESCRIPTION
```@SpringBootApplication``` 默认是包含 ```@EnableAutoConfiguration```, 不需要重复设置
顺便删除无用的imports